### PR TITLE
Use QMAKE_LFLAGS instead of _LIBS for linker flags

### DIFF
--- a/src/firetools/firetools.pro
+++ b/src/firetools/firetools.pro
@@ -1,6 +1,6 @@
 QMAKE_CXXFLAGS += $$(CXXFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
 QMAKE_CFLAGS += $$(CFLAGS) -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIE -pie -Wformat -Wformat-security
-QMAKE_LIBS += $$(LDFLAGS) -Wl,-z,relro -Wl,-z,now
+QMAKE_LFLAGS += $$(LDFLAGS) -Wl,-z,relro -Wl,-z,now
 QT += widgets
  HEADERS       = mainwindow.h ../common/utils.h ../common/pid.h ../common/common.h applications.h \
 		  pid_thread.h db.h dbstorage.h dbpid.h stats_dialog.h graph.h firetools.h edit_dialog.h


### PR DESCRIPTION
With a recent Qt5 version I have the problem that flags in $$(LDFLAGS) were escaped when QMAKE_LIBS is used.
e.g., when I had exported
`LDFLAGS="-fPIE -pie -Wl,-z,relro -Wl,-z,now"`
it was transformed to
`LIBS          = $(SUBLIBS) -L/usr/X11R6/lib64 -fPIE\ -pie\ -Wl,-z,relro\ -Wl,-z,now -Wl,-z,relro -Wl,-z,now -lQt5Widgets -lQt5Gui -lQt5Core -lGL -lpthread`
in the Makefile.
Using QMAKE_LFLAGS is working as intended.
