### PR TITLE
License clarifications

### DIFF
--- a/README
+++ b/README
@@ -4,13 +4,13 @@ Download: http://sourceforge.net/projects/firejail/files/
 Dependencies: firejail, QT4 library, qmake, xterm
 Build and install: ./configure && make && sudo make install
 Documentation and support: http://firejail.sourceforge.net
-License: GPL v2
+License: GPL v2 or later
 
 
 Firetools Authors:
 
 netblue30 (netblue30@yahoo.com)
-Terminal icon (gnome-terminal.png) taken from Gnome project, licese GPL.
-Icedove icon (icedove.png) taken from Debian project, license GPL.
+Terminal icon (gnome-terminal.png) taken from Gnome project, license LGPL v3 or CC BY-SA 3.0.
+Icedove icon (icedove.png) taken from Debian project, license MPL 1.1 or GPL v2 or LGPL v2.1.
 
 Copyright (C) 2015 Firejail Authors


### PR DESCRIPTION
This clarifies the license information in the README.
All firetools source files state a license of GPL v2 **or later**.

And the licenses of the icons are now more accurate, sources were [1] and [2].

1: https://tracker.debian.org/media/packages/i/icedove/copyright-38.6.0-1
2: https://tracker.debian.org/media/packages/g/gnome-icon-theme/copyright-3.12.0-1
