### PR TITLE
remove top message from File Manager window

### DIFF
--- a/src/fmgr/mainwindow.cpp
+++ b/src/fmgr/mainwindow.cpp
@@ -140,7 +140,7 @@ void MainWindow::print_files(const char *path) {
 		printf("print_files path %s\n", path);
 
 	char *cmd;
-	if (asprintf(&cmd, "firejail --ls=%d %s 2>&1", pid_, path) == -1)
+	if (asprintf(&cmd, "firejail --quiet --ls=%d %s 2>&1", pid_, path) == -1)
 		errExit("asprintf");
 
 	// clear table


### PR DESCRIPTION
Leftovers from "Switching to pid 1234, the first child process inside the sandbox".

This bug got introduced with commit "refactor, check the sandbox status for all join options" ec7f59b8d370c29bd229fa9124640611c0667159 in the Firejail repo