### PR TITLE
Add AppStream files.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -39,6 +39,7 @@ distclean: clean
 realinstall:
 	mkdir -p $(DESTDIR)/$(PREFIX)/bin
 	mkdir -p $(DESTDIR)/$(PREFIX)/share/applications
+	mkdir -p $(DESTDIR)/$(PREFIX)/share/metainfo
 	mkdir -p $(DESTDIR)/$(PREFIX)/share/pixmaps
 	mkdir -p $(DESTDIR)/$(PREFIX)/lib/firetools
 	mkdir -p $(DESTDIR)/$(DOCDIR)
@@ -51,7 +52,9 @@ realinstall:
 	install -c -m 0644 src/firejail-ui/uimenus $(DESTDIR)/$(PREFIX)/lib/firetools/.
 	install -c -m 0644 src/firejail-ui/uihelp $(DESTDIR)/$(PREFIX)/lib/firetools/.
 	install -c -m 0644 src/firetools/firetools.desktop $(DESTDIR)/$(PREFIX)/share/applications/.
+	install -c -m 0644 src/firetools/firetools.metainfo.xml $(DESTDIR)/$(PREFIX)/share/metainfo/.
 	install -c -m 0644 src/firejail-ui/firejail-ui.desktop $(DESTDIR)/$(PREFIX)/share/applications/.
+	install -c -m 0644 src/firejail-ui/firejail-ui.metainfo.xml $(DESTDIR)/$(PREFIX)/share/metainfo/.
 	install -c -m 0644 src/firetools/resources/firetools.png $(DESTDIR)/$(PREFIX)/share/pixmaps/.
 	install -c -m 0644 src/firetools/resources/firetools-minimal.png $(DESTDIR)/$(PREFIX)/share/pixmaps/.
 	install -c -m 0644 src/firejail-ui/resources/firejail-ui.png $(DESTDIR)/$(PREFIX)/share/pixmaps/.
@@ -80,6 +83,8 @@ uninstall:;
 	rm -f $(DESTDIR)/$(PREFIX)/share/pixmaps/firejail-ui.png
 	rm -f $(DESTDIR)/$(PREFIX)/share/applications/firetools.desktop
 	rm -f $(DESTDIR)/$(PREFIX)/share/applications/firejail-ui.desktop
+	rm -f $(DESTDIR)/$(PREFIX)/share/metainfo/firetools.metainfo.xml
+	rm -f $(DESTDIR)/$(PREFIX)/share/metainfo/firejail-ui.metainfo.xml
 	rm -fr $(DESTDIR)/$(PREFIX)/share/doc/firetools
 	rm -fr $(DESTDIR)/$(PREFIX)/share/man/man1/firetools.1*
 	rm -fr $(DESTDIR)/$(PREFIX)/share/man/man1/firejail-ui.1*

--- a/src/firejail-ui/firejail-ui.metainfo.xml
+++ b/src/firejail-ui/firejail-ui.metainfo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>firejail-ui.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only AND GPL-2.0-or-later AND CC-BY-SA-3.0 AND MPL-2.0 AND GPL-1.0-only AND LGPL-2.0-only</project_license>
+  <name>Firejail Configuration Wizard</name>
+  <summary>Configuration wizard for Firejail</summary>
+  <description>
+    <p>
+      Configuration wizard that creates application profiles for
+      the Firejail security sandbox.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen7.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen8.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen9.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2021/01/screen10.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://firejailtools.wordpress.com/</url>
+  <url type="bugtracker">https://github.com/netblue30/firetools/issues</url>
+</component>

--- a/src/firetools/firetools.metainfo.xml
+++ b/src/firetools/firetools.metainfo.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>firetools.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only AND GPL-2.0-or-later AND CC-BY-SA-3.0 AND MPL-2.0 AND GPL-1.0-only AND LGPL-2.0-only</project_license>
+  <name>Firetools</name>
+  <summary>Firejail tools and stats</summary>
+  <description>
+    <p>
+      A Firejail sandbox launcher integrated with the system tray,
+      sandbox editing, management and statistics.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen1.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen3.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen2.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen5.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen6.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://firejailtools.wordpress.com/wp-content/uploads/2019/11/screen4.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://firejailtools.wordpress.com/</url>
+  <url type="bugtracker">https://github.com/netblue30/firetools/issues</url>
+</component>


### PR DESCRIPTION
Add metainfo files for [AppStream](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps). This allows finer grained control over how `firejail-ui` and `firetools` appear in graphical software installation tools.